### PR TITLE
use AB::MB for configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -110,7 +110,7 @@ my $builder = $class
            dist_author          => q{Salvador Fandiño <sfandino@yahoo.com>},
            dist_version_from    => 'lib/Alien/Libgcrypt.pm',
            add_to_cleanup       => [ 'Alien-Libgcrypt-*' ],
-           configure_requires   => { 'Alien::Base' => '0.024',
+           configure_requires   => { 'Alien::Base::ModuleBuild' => '0.024',
                                      'Module::Build' => '0.36' },
            alien_bin_requires   => { 'Alien::Libgpg_error' => 0 },
            alien_name           => 'libgcrypt',


### PR DESCRIPTION
This will future proof this dist when/if `Alien::Base::ModuleBuild` is split off from `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
